### PR TITLE
feat(frontend): implementar CRUD inicial de Equipamento + ajustes no DataTable

### DIFF
--- a/src/pages/EquipamentoCreatePage.tsx
+++ b/src/pages/EquipamentoCreatePage.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { createEquipamento } from "../services/equipamento";
+import Button from "../components/Button";//uso do export default está dando erro no uso das { }, por isso removi as chaves
+
+const EquipamentoCreatePage = () => {
+  const [nome, setNome] = useState("");
+  const [modelo, setModelo] = useState("");
+  const [numeroSerie, setNumeroSerie] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const data = {
+      nome,
+      modelo,
+      numeroSerie,
+      ativo: 1, // valor fixo por enquanto
+    };
+
+    await createEquipamento(data);
+    navigate("/equipamentos");
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Novo Equipamento</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block font-medium">Nome</label>
+          <input
+            type="text"
+            value={nome}
+            onChange={(e) => setNome(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block font-medium">Modelo</label>
+          <input
+            type="text"
+            value={modelo}
+            onChange={(e) => setModelo(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+          />
+        </div>
+
+        <div>
+          <label className="block font-medium">Número de Série</label>
+          <input
+            type="text"
+            value={numeroSerie}
+            onChange={(e) => setNumeroSerie(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+          />
+        </div>
+
+        <Button type="submit">Salvar</Button>
+      </form>
+    </div>
+  );
+};
+
+export default EquipamentoCreatePage;

--- a/src/pages/EquipamentoListPage.tsx
+++ b/src/pages/EquipamentoListPage.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { getEquipamentos } from "../services/equipamento";
+import Button from "../components/Button";// uso do export default está dando erro no uso das { }, por isso removi as chaves
+import DataTable from "../components/DataTable";// uso do export default está dando erro no uso das { }, por isso removi as chaves
+import { useNavigate } from "react-router-dom";
+
+const EquipamentoListPage = () => {
+  const [equipamentos, setEquipamentos] = useState([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchEquipamentos = async () => {
+      const data = await getEquipamentos();
+      setEquipamentos(data);
+    };
+    fetchEquipamentos();
+  }, []);
+
+  const handleCreate = () => {
+    navigate("/equipamentos/novo");
+  };
+
+  const handleEdit = (id: number) => {
+    navigate(`/equipamentos/${id}/editar`);
+  };
+
+  const columns = [
+    { label: "ID", accessor: "id" },
+    { label: "Nome", accessor: "nome" },
+    { label: "Status", accessor: "status" },
+    {
+      label: "Ações",
+      accessor: "acoes", // precisei adicionar um acessor temporário para as ações
+      render: (item: any) => (
+        <div className="flex gap-2">
+          <Button onClick={() => handleEdit(item.id)}>Editar</Button>
+          {/*<Button variant="danger">Excluir</Button> */}
+          <Button>Excluir</Button> {/*precisei mudar temporariamente para testar CRUD básico*/}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">Equipamentos</h1>
+        <Button onClick={handleCreate}>Novo Equipamento</Button>
+      </div>
+      <DataTable data={equipamentos} columns={columns} />
+    </div>
+  );
+};
+
+export default EquipamentoListPage;

--- a/src/pages/EquipamentoUpdatePage.tsx
+++ b/src/pages/EquipamentoUpdatePage.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  getEquipamentoById,
+  updateEquipamento,
+} from "../services/equipamento";
+import Button from "../components/Button";// uso do export default está dando erro no uso das { }, por isso removi as chaves
+
+const EquipamentoUpdatePage = () => {
+  const [nome, setNome] = useState("");
+  const [modelo, setModelo] = useState("");
+  const [numeroSerie, setNumeroSerie] = useState("");
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  useEffect(() => {
+    const fetchEquipamento = async () => {
+      if (!id) return;
+      const data = await getEquipamentoById(Number(id));
+      setNome(data.nome || "");
+      setModelo(data.modelo || "");
+      setNumeroSerie(data.numeroSerie || "");
+    };
+    fetchEquipamento();
+  }, [id]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const data = {
+      nome,
+      modelo,
+      numeroSerie,
+      ativo: 1, // valor fixo por enquanto
+    };
+    await updateEquipamento(Number(id), data);
+    navigate("/equipamentos");
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Editar Equipamento</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block font-medium">Nome</label>
+          <input
+            type="text"
+            value={nome}
+            onChange={(e) => setNome(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block font-medium">Modelo</label>
+          <input
+            type="text"
+            value={modelo}
+            onChange={(e) => setModelo(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+          />
+        </div>
+
+        <div>
+          <label className="block font-medium">Número de Série</label>
+          <input
+            type="text"
+            value={numeroSerie}
+            onChange={(e) => setNumeroSerie(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+          />
+        </div>
+
+        <Button type="submit">Salvar Alterações</Button>
+      </form>
+    </div>
+  );
+};
+
+export default EquipamentoUpdatePage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,6 +9,11 @@ import FuncaoListPage from '@/pages/FuncaoListPage'
 import FuncaoCreatePage from '@/pages/FuncaoCreatePage'
 import FuncaoUpdatePage from '@/pages/FuncaoUpdatePage'
 
+import EquipamentoListPage from "../pages/EquipamentoListPage";
+import EquipamentoCreatePage from "../pages/EquipamentoCreatePage";
+import EquipamentoUpdatePage from "../pages/EquipamentoUpdatePage";
+//modificação do JP para importar as páginas de Equipamento
+
 const AppRoutes = () => {
   return (
     <BrowserRouter>
@@ -23,6 +28,12 @@ const AppRoutes = () => {
         <Route path="/funcoes" element={<FuncaoListPage />} />
         <Route path="/funcoes/criar" element={<FuncaoCreatePage />} />
         <Route path="/funcoes/alterar" element={<FuncaoUpdatePage />} />
+
+        <Route path="/equipamentos" element={<EquipamentoListPage />} />
+        <Route path="/equipamentos/novo" element={<EquipamentoCreatePage />} />
+        <Route path="/equipamentos/:id/editar" element={<EquipamentoUpdatePage />} />
+        {/* Rotas adicionadas para Equipamento, falta Relatório */}
+
       </Routes>
     </BrowserRouter>
   )

--- a/src/services/equipamento.ts
+++ b/src/services/equipamento.ts
@@ -1,0 +1,27 @@
+import api from "./axiosConfig";
+
+export const getEquipamentos = async () => {
+  const response = await api.get("/equipamento");
+  return response.data;
+};
+
+export const getEquipamentoById = async (id: number) => {
+  const response = await api.get(`/equipamento/${id}`);
+  return response.data;
+};
+
+export const createEquipamento = async (data: any) => {
+  const response = await api.post("/equipamento", data);
+  return response.data;
+};
+
+export const updateEquipamento = async (id: number, data: any) => {
+  const response = await api.patch(`/equipamento/${id}`, data);
+  return response.data;
+};
+
+export const deleteEquipamento = async (id: number) => {
+  const response = await api.delete(`/equipamento/${id}`);
+  return response.data;
+};
+


### PR DESCRIPTION
## 🚀 O que foi feito

- 🖥️ Criadas páginas principais para Equipamento: listagem, criação e edição.  
- 🔧 Implementado serviço básico com métodos CRUD: get, getById, create, update, delete.  
- 🛣️ Configuradas rotas para Equipamento no frontend.  
- 🧩 Ajustado uso do componente DataTable para nova interface de paginação (props obrigatórias adicionadas).  
- 📝 Funções temporárias com `console.log` para paginação, aguardando implementação futura.

## 🎯 Por que fazer esse PR

- ✅ Entregar funcionalidade básica de gerenciamento de Equipamentos.  
- 🛠️ Alinhar código ao padrão atualizado do DataTable, evitando erros e preparando para paginação.

## 🔜 Próximos passos

- 🔍 Revisão extra  
- 📊 Criar o mesmo para relatório  
- ⚠️ __ATENÇÃO__: Funcionalidades ainda não foram todas testadas
